### PR TITLE
Add support for INTL subdomain login

### DIFF
--- a/custom_components/fusionsolarplus/api/fusion_solar_py/client.py
+++ b/custom_components/fusionsolarplus/api/fusion_solar_py/client.py
@@ -376,7 +376,9 @@ class FusionSolarClient:
 
         headers = {"App-Id": "smartpvms"}
 
-        r = self._session.post(url=url, params=url_params, json=json_data, headers=headers)
+        r = self._session.post(
+            url=url, params=url_params, json=json_data, headers=headers
+        )
         r.raise_for_status()
 
         try:
@@ -388,7 +390,9 @@ class FusionSolarClient:
 
         # INTL uses "code" instead of "errorCode"
         if login_response.get("code") != 0:
-            error_msg = login_response.get("payload", {}).get("exceptionMessage", "Unknown error")
+            error_msg = login_response.get("payload", {}).get(
+                "exceptionMessage", "Unknown error"
+            )
             raise AuthenticationException(
                 f"Failed to login into FusionSolarAPI (INTL): {error_msg}"
             )


### PR DESCRIPTION
The intl.fusionsolar.huawei.com subdomain uses a different authentication API than the EU5 regions:

- Login endpoint: /rest/dp/uidm/unisso/v1/validate-user (not /unisso/v3/validateUser.action)
- No password encryption required
- Requires App-Id: smartpvms header
- Response uses "code" field instead of "errorCode"

Also fixes hardcoded eu5.fusionsolar.huawei.com pubkey URL to use the configured login subdomain.