### PR TITLE
Treat "--" as a null sentinel in plant data

### DIFF
--- a/custom_components/fusionsolarplus/api/devices/plant_api.py
+++ b/custom_components/fusionsolarplus/api/devices/plant_api.py
@@ -172,7 +172,7 @@ def get_current_plant_data(client: Any, plant_id: str) -> dict:
         if key.startswith("exist"):
             data[key] = bool(value)
             continue
-        if value in (None, "-", "N/A", "n/a"):
+        if value in (None, "-", "--", "N/A", "n/a"):
             data[key] = None
             continue
         try:

--- a/custom_components/fusionsolarplus/devices/plant/sensor.py
+++ b/custom_components/fusionsolarplus/devices/plant/sensor.py
@@ -113,6 +113,14 @@ class FusionSolarPlantSensor(CoordinatorEntity, SensorEntity):
         if value is None:
             return None
 
+        # The scraped portal can still yield non-numeric values.
+        # Coerce here so a stray string can never reach the numeric
+        # comparisons below nor be stored in _last_valid_value.
+        try:
+            value = float(value)
+        except (TypeError, ValueError):
+            return None
+
         # --- Spike suppression ---
         if self._last_valid_value is not None and self._last_valid_value > 0:
             absolute_jump = value - self._last_valid_value

--- a/custom_components/fusionsolarplus/manifest.json
+++ b/custom_components/fusionsolarplus/manifest.json
@@ -13,5 +13,5 @@
     "beautifulsoup4",
     "gradio_client"
   ],
-  "version": "2.3.3"
+  "version": "2.3.4"
 }


### PR DESCRIPTION
### The problem

The FusionSolar portal returns `"--"` when a value isn't available yet — which happens every day around midnight, while the daily counters reset.

`get_current_plant_data()` doesn't list `"--"` among its null sentinels, so `float("--")` raises `ValueError` and the `except` branch stores the raw string. `native_value()` then assigns that string to `_last_valid_value`, and every subsequent update raises:

```
TypeError: '>' not supported between instances of 'str' and 'int'
```

Since `_last_valid_value` is never cleared, **the sensor stays poisoned for the rest of the run**. On my instance this produced ~680 exceptions/hour for over nine hours (13k log lines), with six plant sensors frozen at `0.0` while the inverter kept reporting correctly.

Worth noting: `"--"` is *already* handled as a null sentinel elsewhere in this same file — in `get_last_plant_data()` and `get_last_value()`. This just makes `get_current_plant_data()` consistent with them.

### The changes (9 lines)

- **`plant_api.py`**: add `"--"` to the sentinel tuple, so the value becomes `None` and the sensor correctly reports `unknown` instead of a bogus string.
- **`plant/sensor.py`**: defensive `float()` coercion in `native_value()`, so any future non-numeric value returns `None` instead of poisoning `_last_valid_value` and both numeric comparisons below.

Probably also fixes #116 (*"invalid literal for int() with base 10: '--'"*), which looks like the same root cause surfacing as a state-validation error.

### Testing

Applied to a live 2.3.3 installation: `fusionsolarplus` errors went from 13,119 log lines to **zero**, and the frozen sensors resumed reporting within minutes.